### PR TITLE
adding compatibility with Composer 2.2+

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,15 @@ runs:
         COMPOSER_HOME: /tmp/.satis-build
       run: |
         mkdir /tmp/.satis-build
-        echo "{}" > /tmp/.satis-build/composer.json
+        cat << 'EOF' > /tmp/.satis-build/composer.json
+        {
+          "config": {
+            "allow-plugins": {
+              "composer/satis": true
+            }
+          }
+        }
+        EOF
 
         composer g require composer/satis:dev-main --prefer-dist \
           --no-cache --no-progress --no-interaction -o \


### PR DESCRIPTION
Closes #1 

The change was tested with Composer 2.1, 2.2, 2.3, and 2.7. Versions 2.1 and 2.2 show a non-breaking warning about a Composer plugin API version mismatch which is expected.